### PR TITLE
Ensure bundled templates are found in one-file build

### DIFF
--- a/logic/excel_exporter.py
+++ b/logic/excel_exporter.py
@@ -12,16 +12,15 @@ from openpyxl.cell import Cell
 from openpyxl.utils import get_column_letter
 from openpyxl.drawing.spreadsheet_drawing import OneCellAnchor, TwoCellAnchor
 from openpyxl.drawing.image import Image
+from resource_utils import resource_path
 
 from .service_config import ServiceConfig
 from .translation_config import tr
 
 CURRENCY_SYMBOLS = {"RUB": "₽", "EUR": "€", "USD": "$"}
 
-# Шаблон теперь ищем относительно корня проекта, чтобы код работал на любой машине
-DEFAULT_TEMPLATE_PATH = os.path.join(
-    os.path.dirname(__file__), "..", "templates", "шаблон.modern.xlsx"
-)
+# Шаблон теперь ищем относительно корня проекта или временной папки PyInstaller
+DEFAULT_TEMPLATE_PATH = resource_path("templates/шаблон.modern.xlsx")
 
 START_PH = "{{translation_table}}"
 END_PH = "{{subtotal_translation_table}}"
@@ -735,9 +734,7 @@ class ExcelExporter:
         template: str
             Код шаблона, соответствующий имени файла логотипа.
         """
-        logo_path = os.path.join(
-            os.path.dirname(__file__), "..", "templates", "logos", f"{template}.png"
-        )
+        logo_path = resource_path(f"templates/logos/{template}.png")
         if not os.path.exists(logo_path):
             self.logger.debug("Logo not found for template %s: %s", template, logo_path)
             return

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import sys
-from pathlib import Path
+
+from resource_utils import resource_path
 
 from PySide6.QtWidgets import QApplication
 from PySide6.QtGui import QIcon
@@ -10,7 +11,7 @@ from logic.excel_process import close_excel_processes
 def main() -> int:
     app = QApplication(sys.argv)
 
-    icon_path = Path(__file__).resolve().parent / "rateapp.ico"
+    icon_path = resource_path("rateapp.ico")
     icon = QIcon(str(icon_path))
     app.setWindowIcon(icon)
 

--- a/resource_utils.py
+++ b/resource_utils.py
@@ -1,0 +1,19 @@
+"""Utility helpers for accessing bundled resources."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+def resource_path(relative: str) -> Path:
+    """Return absolute path to resource for dev and PyInstaller builds.
+
+    Parameters
+    ----------
+    relative:
+        Path to the resource relative to the project root or the temporary
+        directory used by PyInstaller.
+    """
+    base_path = getattr(sys, "_MEIPASS", Path(__file__).resolve().parent)
+    return Path(base_path) / relative


### PR DESCRIPTION
## Summary
- Add `resource_path` helper that supports PyInstaller's `_MEIPASS`
- Load icons and Excel templates via `resource_path`

## Testing
- `python -m py_compile main.py logic/excel_exporter.py resource_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c20c358f0c832cb62d540468ecd9bc