### PR TITLE
Add Smartcat report parsing with improved error handling

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -615,7 +615,7 @@ class TranslationCostCalculator(QMainWindow):
         if getattr(self, "drop_hint_label", None):
             self.drop_hint_label.setText(
                 tr(
-                    "Перетащите XML файлы отчетов Trados сюда для автоматического заполнения",
+                    "Перетащите XML файлы отчетов Trados или Smartcat сюда для автоматического заполнения",
                     lang,
                 )
             )
@@ -756,7 +756,7 @@ class TranslationCostCalculator(QMainWindow):
 
         self.drop_hint_label = QLabel(
             tr(
-                "Перетащите XML файлы отчетов Trados сюда для автоматического заполнения",
+                "Перетащите XML файлы отчетов Trados или Smartcat сюда для автоматического заполнения",
                 gui_lang,
             )
         )

--- a/logic/translation_config.py
+++ b/logic/translation_config.py
@@ -101,9 +101,9 @@ TRANSLATIONS = {
     "Конвертировать в рубли": {"ru": "Конвертировать в рубли", "en": "Convert to RUB"},
     "Курс USD": {"ru": "Курс USD", "en": "USD rate"},
     "1 USD в рублях": {"ru": "1 USD в рублях", "en": "1 USD in RUB"},
-    "Перетащите XML файлы отчетов Trados сюда для автоматического заполнения": {
-        "ru": "Перетащите XML файлы отчетов Trados сюда для автоматического заполнения",
-        "en": "Drag Trados XML report files here for automatic filling",
+    "Перетащите XML файлы отчетов Trados или Smartcat сюда для автоматического заполнения": {
+        "ru": "Перетащите XML файлы отчетов Trados или Smartcat сюда для автоматического заполнения",
+        "en": "Drag Trados or Smartcat XML report files here for automatic filling",
     },
     "Обновление": {"ru": "Обновление", "en": "Update"},
     "Проверить обновления": {"ru": "Проверить обновления", "en": "Check for updates"},


### PR DESCRIPTION
## Summary
- add Smartcat XML detection and parsing with helpers for number normalization and language inference
- refactor `parse_reports` to route Trados and Smartcat files, surface filename-based warnings, and insert placeholder pairs when parsing fails
- mention Smartcat support in the drag-and-drop hint text

## Testing
- python -m compileall smeta

------
https://chatgpt.com/codex/tasks/task_e_68c88f8e5808832c9a78921f013ff889