### PR TITLE
Improve Windows update workflow

### DIFF
--- a/logic/translation_config.py
+++ b/logic/translation_config.py
@@ -128,9 +128,17 @@ TRANSLATIONS = {
         "ru": "Обновление установлено. Перезапустите программу.",
         "en": "Update installed. Please restart the application.",
     },
+    "Обновление скачано. Программа закроется для установки обновления.": {
+        "ru": "Обновление скачано. Программа закроется для установки обновления.",
+        "en": "Update downloaded. The application will close to finish installation.",
+    },
     "Ошибка при установке обновления: {0}": {
         "ru": "Ошибка при установке обновления: {0}",
         "en": "Failed to install update: {0}",
+    },
+    "Не удалось подготовить установку обновления: {0}": {
+        "ru": "Не удалось подготовить установку обновления: {0}",
+        "en": "Failed to prepare update installation: {0}",
     },
 }
 


### PR DESCRIPTION
## Summary
- rework the updater to schedule installation through a helper script on Windows so the executable can be replaced after the app exits
- add localized strings for the new updater messages shown during the download and error handling flow

## Testing
- python -m compileall updater/auto_updater.py logic/translation_config.py

------
https://chatgpt.com/codex/tasks/task_e_68c96c4c2bd0832c87812432aa384ad0