### PR TITLE
Show update progress dialog and handle missing Babel data

### DIFF
--- a/logic/language_codes.py
+++ b/logic/language_codes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import csv
 import re
+from contextlib import suppress
 from functools import lru_cache
 from pathlib import Path
 from typing import Dict
@@ -170,11 +171,13 @@ def _babel_country_map() -> Dict[str, str]:
             locale = Locale(lang)
         except Exception:
             continue
-        for code, display in locale.territories.items():
-            mapping[_normalize(display)] = code.upper()
-        short_map = locale._data.get("short_territories", {})
-        for code, display in short_map.items():
-            mapping[_normalize(display)] = code.upper()
+        with suppress(Exception):
+            for code, display in locale.territories.items():
+                mapping[_normalize(display)] = code.upper()
+        with suppress(Exception):
+            short_map = locale._data.get("short_territories", {})
+            for code, display in short_map.items():
+                mapping[_normalize(display)] = code.upper()
 
     for code, short in RU_TERRITORY_ABBREVIATIONS.items():
         mapping[_normalize(short)] = code

--- a/logic/translation_config.py
+++ b/logic/translation_config.py
@@ -140,6 +140,18 @@ TRANSLATIONS = {
         "ru": "Не удалось подготовить установку обновления: {0}",
         "en": "Failed to prepare update installation: {0}",
     },
+    "Проверка обновления...": {
+        "ru": "Проверка обновления...",
+        "en": "Checking for updates...",
+    },
+    "Загрузка обновления...": {
+        "ru": "Загрузка обновления...",
+        "en": "Downloading update...",
+    },
+    "Проверка файла обновления...": {
+        "ru": "Проверка файла обновления...",
+        "en": "Verifying download...",
+    },
 }
 
 def tr(text: str, lang: str) -> str:


### PR DESCRIPTION
## Summary
- show an indeterminate progress dialog while checking for application updates and update the status text for each step
- add translations for the new progress messages
- make language resolution resilient to missing Babel data files when running from packaged builds

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c9d31916dc832cae52c659eb79286f