### PR TITLE
Handle mismatched territories for script-only language tags

### DIFF
--- a/logic/language_codes.py
+++ b/logic/language_codes.py
@@ -70,9 +70,27 @@ def _territory_from_code(code: str) -> str:
     if territory:
         return territory.upper()
 
+    base_language = (lang.language or "").lower()
+    if not base_language:
+        parts = [part for part in normalized.split("-") if part]
+        if parts:
+            base_language = parts[0].lower()
+
     # Try to extract territory from maximised tag (e.g. ``pt`` -> ``PT``)
     maximized = lang.maximize()
     if maximized.territory:
+        max_language = (maximized.language or "").lower()
+        if base_language and max_language and max_language != base_language:
+            if lang.script and base_language:
+                with suppress(langcodes.LanguageTagError):
+                    base_maximized = langcodes.Language.get(base_language).maximize()
+                    base_territory = base_maximized.territory or ""
+                    if (
+                        base_territory
+                        and (base_maximized.language or "").lower() == base_language
+                    ):
+                        return base_territory.upper()
+            return ""
         return maximized.territory.upper()
 
     return ""

--- a/tests/test_language_codes.py
+++ b/tests/test_language_codes.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import patch
+
+from logic import language_codes
+
+
+class _DummyLanguage:
+    def __init__(self, language="", territory="", script="", maximized=None):
+        self.language = language
+        self.territory = territory
+        self.script = script
+        self._maximized = maximized or self
+
+    def maximize(self):
+        return self._maximized
+
+
+class TerritoryDetectionTests(unittest.TestCase):
+    def test_script_only_code_ignores_mismatched_language_territory(self):
+        base_maximized = _DummyLanguage(language="uz", territory="UZ", script="Latn")
+        base_language = _DummyLanguage(language="az", script="Latn", maximized=base_maximized)
+
+        fallback_maximized = _DummyLanguage(language="az", territory="AZ")
+        fallback_language = _DummyLanguage(language="az", maximized=fallback_maximized)
+
+        def fake_get(tag):
+            if tag == "az-Latn":
+                return base_language
+            if tag == "az":
+                return fallback_language
+            raise language_codes.langcodes.LanguageTagError
+
+        with patch.object(language_codes.langcodes.Language, "get", side_effect=fake_get):
+            short = language_codes.determine_short_code("az-Latn", "", "", "")
+
+        self.assertEqual(short, "AZ")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure script-only language tags ignore territories inferred for a different language
- fall back to the base language’s territory when available so Azerbaijani retains AZ instead of UZ
- add a unit test covering the Smartcat Azerbaijani Latin scenario

## Testing
- python -m unittest discover tests

------
https://chatgpt.com/codex/tasks/task_e_68e296177a58832cadb99fa5bca85a74