### PR TITLE
Add targeted unit tests for core logic helpers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_excel_process.py
+++ b/tests/test_excel_process.py
@@ -1,0 +1,176 @@
+import sys
+import types
+
+from logic import excel_process
+
+
+class _FakeProc:
+    def __init__(self, name: str, terminate_raises: bool = False):
+        self.info = {"name": name}
+        self.terminated = False
+        self.killed = False
+        self._terminate_raises = terminate_raises
+
+    def terminate(self):
+        if self._terminate_raises:
+            raise RuntimeError("terminate failed")
+        self.terminated = True
+
+    def wait(self, timeout=None):
+        return True
+
+    def kill(self):
+        self.killed = True
+
+
+def test_close_excel_processes_skips_on_non_windows(monkeypatch):
+    called = False
+
+    class _Sentinel:
+        @staticmethod
+        def process_iter(_):
+            nonlocal called
+            called = True
+            return []
+
+    monkeypatch.setattr(excel_process.sys, "platform", "linux")
+    monkeypatch.setattr(excel_process, "psutil", _Sentinel)
+
+    excel_process.close_excel_processes()
+
+    assert called is False
+
+
+def test_close_excel_processes_terminates_matching_processes(monkeypatch):
+    target = _FakeProc("EXCEL.EXE")
+    other = _FakeProc("notepad.exe")
+
+    class _FakePsutil:
+        @staticmethod
+        def process_iter(_):
+            return [target, other]
+
+    monkeypatch.setattr(excel_process.sys, "platform", "win32")
+    monkeypatch.setattr(excel_process, "psutil", _FakePsutil)
+
+    excel_process.close_excel_processes()
+
+    assert target.terminated is True
+    assert other.terminated is False
+    assert target.killed is False
+
+
+def test_close_excel_processes_kills_when_terminate_fails(monkeypatch):
+    target = _FakeProc("excel.exe", terminate_raises=True)
+
+    class _FakePsutil:
+        @staticmethod
+        def process_iter(_):
+            return [target]
+
+    monkeypatch.setattr(excel_process.sys, "platform", "win32")
+    monkeypatch.setattr(excel_process, "psutil", _FakePsutil)
+
+    excel_process.close_excel_processes()
+
+    assert target.killed is True
+
+
+class _FakeWorkbook:
+    def __init__(self, should_fail: bool = False):
+        self.saved = False
+        self.closed = False
+        self._should_fail = should_fail
+
+    def Save(self):
+        self.saved = True
+        if self._should_fail:
+            raise RuntimeError("cannot save")
+
+    def Close(self, save_changes):
+        self.closed = True
+
+
+class _FakeWorkbooks:
+    def __init__(self, workbook: _FakeWorkbook):
+        self.workbook = workbook
+        self.opened_path = None
+
+    def Open(self, path: str):
+        self.opened_path = path
+        return self.workbook
+
+
+class _FakeExcel:
+    def __init__(self, workbook: _FakeWorkbook):
+        self.DecimalSeparator = ","
+        self.ThousandsSeparator = " "
+        self.UseSystemSeparators = True
+        self.Visible = True
+        self.DisplayAlerts = True
+        self.workbook = workbook
+        self.Workbooks = _FakeWorkbooks(workbook)
+        self.quit_called = False
+
+    def Quit(self):
+        self.quit_called = True
+
+
+def _install_fake_win32(monkeypatch, excel_instance):
+    fake_client = types.SimpleNamespace(Dispatch=lambda name: excel_instance)
+    fake_module = types.SimpleNamespace(client=fake_client)
+    monkeypatch.setitem(sys.modules, "win32com", fake_module)
+    monkeypatch.setitem(sys.modules, "win32com.client", fake_client)
+
+
+def test_temporary_separators_sets_and_restores():
+    excel = types.SimpleNamespace(
+        DecimalSeparator=",",
+        ThousandsSeparator=" ",
+        UseSystemSeparators=True,
+    )
+
+    with excel_process.temporary_separators(excel, "en-GB"):
+        assert excel.DecimalSeparator == "."
+        assert excel.ThousandsSeparator == ","
+        assert excel.UseSystemSeparators is False
+
+    assert excel.DecimalSeparator == ","
+    assert excel.ThousandsSeparator == " "
+    assert excel.UseSystemSeparators is True
+
+
+def test_apply_separators_success(monkeypatch, tmp_path):
+    workbook = _FakeWorkbook()
+    excel = _FakeExcel(workbook)
+
+    _install_fake_win32(monkeypatch, excel)
+
+    xlsx_path = tmp_path / "example.xlsx"
+    xlsx_path.write_text("dummy")
+
+    assert excel_process.apply_separators(str(xlsx_path), "en") is True
+
+    assert excel.Workbooks.opened_path == str(xlsx_path)
+    assert workbook.saved is True
+    assert workbook.closed is True
+    assert excel.quit_called is True
+    assert excel.DecimalSeparator == ","
+    assert excel.ThousandsSeparator == " "
+    assert excel.UseSystemSeparators is True
+
+
+def test_apply_separators_handles_failure_and_cleans_up(monkeypatch, tmp_path):
+    workbook = _FakeWorkbook(should_fail=True)
+    excel = _FakeExcel(workbook)
+
+    _install_fake_win32(monkeypatch, excel)
+
+    xlsx_path = tmp_path / "example.xlsx"
+    xlsx_path.write_text("dummy")
+
+    assert excel_process.apply_separators(str(xlsx_path), "ru") is False
+
+    assert workbook.closed is True
+    assert excel.quit_called is True
+    assert excel.UseSystemSeparators is True

--- a/tests/test_project_io.py
+++ b/tests/test_project_io.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+
+from logic import project_io
+
+
+def test_save_project_writes_json(tmp_path):
+    data = {"name": "Example", "items": [1, 2, 3]}
+    target = tmp_path / "project.json"
+
+    assert project_io.save_project(data, target) is True
+
+    loaded = json.loads(target.read_text(encoding="utf-8"))
+    assert loaded == data
+
+
+def test_save_project_returns_false_on_error(tmp_path):
+    data = {"key": "value"}
+    target_dir = tmp_path / "dir"
+    target_dir.mkdir()
+
+    assert project_io.save_project(data, target_dir) is False
+
+
+def test_load_project_reads_json(tmp_path):
+    payload = {"currency": "USD"}
+    source = tmp_path / "project.json"
+    source.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert project_io.load_project(source) == payload
+
+
+def test_load_project_returns_none_when_missing(tmp_path):
+    assert project_io.load_project(tmp_path / "missing.json") is None
+
+
+def test_load_project_returns_none_on_invalid_json(tmp_path):
+    source = tmp_path / "broken.json"
+    source.write_text("not json", encoding="utf-8")
+
+    assert project_io.load_project(source) is None

--- a/tests/test_resource_utils.py
+++ b/tests/test_resource_utils.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import resource_utils
+
+
+def test_resource_path_uses_package_directory():
+    relative = "templates/example.txt"
+    expected = Path(resource_utils.__file__).resolve().parent / relative
+    assert resource_utils.resource_path(relative) == expected
+
+
+def test_resource_path_uses_meipass_when_available(monkeypatch, tmp_path):
+    base = tmp_path / "bundle"
+    base.mkdir()
+    monkeypatch.setattr(resource_utils.sys, "_MEIPASS", str(base), raising=False)
+
+    result = resource_utils.resource_path("foo/bar.txt")
+    assert result == base / "foo/bar.txt"

--- a/tests/test_translation_config.py
+++ b/tests/test_translation_config.py
@@ -1,0 +1,14 @@
+from logic.translation_config import tr
+
+
+def test_tr_returns_translation_when_available():
+    assert tr("Перевод", "en") == "Translation"
+
+
+def test_tr_falls_back_to_original_when_missing_phrase():
+    missing = "Unknown phrase"
+    assert tr(missing, "ru") == missing
+
+
+def test_tr_falls_back_to_original_when_missing_language():
+    assert tr("Перевод", "de") == "Перевод"


### PR DESCRIPTION
## Summary
- add a test configuration to expose the repository root on the Python path
- cover Excel process management helpers with focused unit tests
- add granular tests for language code utilities, project IO, resource helpers, and translations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e29a4b2acc832ca6ba9eb60225e31d