### PR TITLE
Show errors when MSG import fails

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import tempfile
 import re
+import traceback
 from datetime import datetime
 from typing import Dict, List, Any, Tuple, Optional
 
@@ -221,7 +222,13 @@ class ProjectInfoDropArea(QGroupBox):
         try:
             self._callback(msg_paths)
             event.acceptProposedAction()
-        except Exception:
+        except Exception as exc:
+            traceback.print_exc()
+            QMessageBox.critical(
+                self,
+                "Ошибка обработки Outlook файла",
+                str(exc) or "Не удалось обработать перетащенный .msg файл.",
+            )
             event.ignore()
 
 


### PR DESCRIPTION
## Summary
- add traceback logging for failures when dropping Outlook MSG files
- surface an error dialog if MSG import raises an exception during drag and drop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2f2a7d46c832ca417613aaf4848a2