### PR TITLE
Ensure language slider switches to English for Logrus IT

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -723,6 +723,14 @@ class TranslationCostCalculator(QMainWindow):
     def on_legal_entity_changed(self, entity: str):
         if entity == self.legal_entity_placeholder:
             entity = ""
+
+        normalized_entity = entity.strip() if entity else ""
+        if (
+            normalized_entity.lower() == "logrus it"
+            and self.lang_mode_slider.value() == 1
+        ):
+            self.lang_mode_slider.setValue(0)
+
         meta = self.legal_entity_meta.get(entity, {}) if entity else {}
         vat_enabled = bool(meta.get("vat_enabled"))
         self.vat_spin.setEnabled(vat_enabled)


### PR DESCRIPTION
## Summary
- ensure selecting the Logrus IT legal entity flips the language slider to English when it was previously Russian

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'babel')*


------
https://chatgpt.com/codex/tasks/task_e_68e2fecfd48c832c8f6680a2ddba2042