### PR TITLE
Fix export progress dialog appearance

### DIFF
--- a/logic/progress.py
+++ b/logic/progress.py
@@ -6,9 +6,16 @@ class Progress:
     """Wrapper around QProgressDialog for export progress."""
 
     def __init__(self, title: str = "Сохранение...", parent=None) -> None:
-        self.dialog = QProgressDialog("Сохранение...", None, 0, 100, parent)
+        self.dialog = QProgressDialog(parent)
         self.dialog.setWindowTitle(title)
         self.dialog.setWindowModality(Qt.WindowModal)
+        self.dialog.setRange(0, 100)
+        self.dialog.setMinimumDuration(0)
+        self.dialog.setAutoClose(False)
+        self.dialog.setAutoReset(False)
+        self.dialog.setCancelButton(None)
+        self.dialog.setLabelText("Сохранение...")
+        self.dialog.resize(self.dialog.sizeHint())
         self.dialog.setValue(0)
 
     def set_label(self, message: str) -> None:


### PR DESCRIPTION
## Summary
- reconfigure the export progress dialog to rely on explicit range setup
- hide the cancel button, prevent auto closing, and size the dialog using its hint to keep the progress bar aligned

## Testing
- pytest *(fails: missing optional dependency `babel`)*

------
https://chatgpt.com/codex/tasks/task_e_68e40accff54832c93a74243d7c6dab3