### PR TITLE
Add open folder option after exports and fix PDF fitting

### DIFF
--- a/logic/excel_exporter.py
+++ b/logic/excel_exporter.py
@@ -399,7 +399,7 @@ class ExcelExporter:
 
     def _fit_sheet_to_page(self, ws: Worksheet) -> None:
         ws.sheet_properties.pageSetUpPr.fitToPage = True
-        ws.page_setup.fitToHeight = 1
+        ws.page_setup.fitToHeight = 0
         ws.page_setup.fitToWidth = 1
         self._set_print_area(ws)
 


### PR DESCRIPTION
## Summary
- add a reusable success dialog for exports with an "Open folder" action that reveals the generated file
- adjust PDF export scaling so only the columns are fit onto a single page

## Testing
- python -m compileall gui/main_window.py logic/excel_exporter.py

------
https://chatgpt.com/codex/tasks/task_e_68e42ff5cf80832c8c6f783134ce97d6