### PR TITLE
Track Excel instances created by the app

### DIFF
--- a/logic/pdf_exporter.py
+++ b/logic/pdf_exporter.py
@@ -4,7 +4,11 @@ import tempfile
 from typing import Dict, Any
 
 from .excel_exporter import ExcelExporter
-from .excel_process import temporary_separators
+from .excel_process import (
+    temporary_separators,
+    register_excel_instance,
+    unregister_excel_instance,
+)
 
 logger = logging.getLogger("PdfExporter")
 
@@ -45,6 +49,7 @@ def xlsx_to_pdf(xlsx_path: str, pdf_path: str, lang: str = "ru") -> bool:
         import win32com.client  # type: ignore
 
         excel = win32com.client.Dispatch("Excel.Application")
+        register_excel_instance(excel)
         excel.Visible = False
         excel.DisplayAlerts = False
 
@@ -65,5 +70,6 @@ def xlsx_to_pdf(xlsx_path: str, pdf_path: str, lang: str = "ru") -> bool:
                 excel.Quit()
             except Exception:
                 pass
+            unregister_excel_instance(excel)
 
     return success

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import QApplication
 from PySide6.QtGui import QIcon
 
 from gui.main_window import TranslationCostCalculator
-from logic.excel_process import close_excel_processes
+from logic.excel_process import close_tracked_excel_instances
 
 def main() -> int:
     app = QApplication(sys.argv)
@@ -25,5 +25,5 @@ if __name__ == "__main__":
     try:
         sys.exit(main())
     finally:
-        # Ensure no hanging Excel processes remain if the application crashes.
-        close_excel_processes()
+        # Ensure that only Excel instances started by the application are closed.
+        close_tracked_excel_instances()


### PR DESCRIPTION
## Summary
- track Excel application instances the app starts and close only those on shutdown
- register/unregister Excel COM objects where they are created
- refresh tests to cover the new tracking behaviour

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'babel')*

------
https://chatgpt.com/codex/tasks/task_e_68e43c51f354832c8793d6901fcaca8a