### PR TITLE
Centralize logging and replace print statements

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,61 @@
+"""Application-wide logging configuration."""
+from __future__ import annotations
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Optional
+
+_LOGGER_NAME = "ProjectCalculator"
+_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
+_BACKUP_COUNT = 3
+
+
+def _determine_log_path() -> Path:
+    """Return the path to the application log file, creating directories if needed."""
+    appdata = os.getenv("APPDATA")
+    if appdata:
+        base_dir = Path(appdata) / "ProjectCalculator"
+    else:
+        # Fallback for non-Windows environments.
+        base_dir = Path.home() / ".config" / "ProjectCalculator"
+
+    log_dir = base_dir / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return log_dir / "app.log"
+
+
+def _configure_root_logger() -> logging.Logger:
+    """Configure and return the application's root logger."""
+    logger = logging.getLogger(_LOGGER_NAME)
+    if logger.handlers:
+        return logger
+
+    logger.setLevel(logging.DEBUG)
+    log_path = _determine_log_path()
+    handler = RotatingFileHandler(
+        log_path,
+        maxBytes=_MAX_BYTES,
+        backupCount=_BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    formatter = logging.Formatter(
+        "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.propagate = False
+    return logger
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a logger instance scoped to the given name."""
+    root_logger = _configure_root_logger()
+    if name:
+        return root_logger.getChild(name)
+    return root_logger
+
+
+# Initialize the root logger on module import.
+logger = get_logger()

--- a/logic/excel_exporter.py
+++ b/logic/excel_exporter.py
@@ -1,6 +1,5 @@
 # logic/excel_exporter.py
 import os
-import logging
 import re
 import textwrap
 from typing import Dict, Any, List, Optional, Tuple, Callable
@@ -17,6 +16,7 @@ from resource_utils import resource_path
 from .service_config import ServiceConfig
 from .translation_config import tr
 from .excel_process import apply_separators
+from logger import get_logger
 
 CURRENCY_SYMBOLS = {"RUB": "₽", "EUR": "€", "USD": "$"}
 
@@ -301,14 +301,9 @@ class ExcelExporter:
         self.ps_hdr_titles = {k: tr(v, lang) for k, v in PS_HDR_TITLES.items()}
         self.add_hdr_titles = {k: tr(v, lang) for k, v in ADD_HDR_TITLES.items()}
         self.subtotal_title = f"{tr('Промежуточная сумма', lang)} ({currency}):"
-        self.logger = logging.getLogger("ExcelExporter")
-        self.logger.setLevel(logging.DEBUG)
-        self.logger.propagate = False
-        if not self.logger.handlers:
-            handler = logging.FileHandler(log_path, mode="w", encoding="utf-8")
-            formatter = logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
-            handler.setFormatter(formatter)
-            self.logger.addHandler(handler)
+        self.logger = get_logger(f"{__name__}.{self.__class__.__name__}")
+        if log_path:
+            self.logger.debug("Legacy log path parameter provided: %s", log_path)
         self.logger.debug(
             "Initialized ExcelExporter with template %s", self.template_path
         )
@@ -584,9 +579,8 @@ class ExcelExporter:
 
             self.logger.info("Export completed successfully")
             return True
-        except Exception as e:
+        except Exception:
             self.logger.exception("Export failed")
-            print(f"[ExcelExporter] Ошибка экспорта: {e}")
             return False
 
     # ----------------------------- ПОИСК/КОПИРОВАНИЕ -----------------------------

--- a/logic/pdf_exporter.py
+++ b/logic/pdf_exporter.py
@@ -1,5 +1,4 @@
 import os
-import logging
 import tempfile
 from typing import Dict, Any
 
@@ -10,7 +9,9 @@ from .excel_process import (
     unregister_excel_instance,
 )
 
-logger = logging.getLogger("PdfExporter")
+from logger import get_logger
+
+logger = get_logger(__name__)
 
 
 def export_to_pdf(
@@ -30,9 +31,8 @@ def export_to_pdf(
             if not xlsx_to_pdf(xlsx_path, output_path, lang=lang):
                 raise RuntimeError("Не удалось конвертировать в PDF")
         return True
-    except Exception as e:
+    except Exception:
         logger.exception("PDF export failed")
-        print(f"[PdfExporter] Ошибка экспорта PDF: {e}")
         return False
 
 

--- a/logic/project_io.py
+++ b/logic/project_io.py
@@ -1,18 +1,23 @@
 import json
 
+from logger import get_logger
+
+
+logger = get_logger(__name__)
+
 def save_project(data, path) -> bool:
     try:
         with open(path, "w", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
         return True
-    except Exception as e:
-        print(f"Ошибка сохранения проекта: {e}")
+    except Exception:
+        logger.exception("Ошибка сохранения проекта")
         return False
 
 def load_project(path):
     try:
         with open(path, "r", encoding="utf-8") as f:
             return json.load(f)
-    except Exception as e:
-        print(f"Ошибка загрузки проекта: {e}")
+    except Exception:
+        logger.exception("Ошибка загрузки проекта")
         return None

--- a/logic/trados_xml_parser.py
+++ b/logic/trados_xml_parser.py
@@ -9,14 +9,18 @@ from pathlib import Path
 from .service_config import ServiceConfig
 from .xml_parser_common import expand_language_code, normalize_language_name
 from .sc_xml_parser import is_smartcat_report, parse_smartcat_report
+from logger import get_logger
 
 
 ROW_NAMES = ServiceConfig.ROW_NAMES
 
 
+logger = get_logger(__name__)
+
+
 def _extract_languages_from_filename(filename: str) -> Tuple[str, str]:
     """Извлекает языки из имени файла типа 'Analyze Files en-US_ru-RU(23).xml'."""
-    print(f"Extracting languages from filename: {filename}")
+    logger.debug("Extracting languages from filename: %s", filename)
 
     pattern = r"([a-z]{2,3}(?:-[A-Z]{2})?)[_-]([a-z]{2,3}(?:-[A-Z]{2})?)"
     match = re.search(pattern, filename, re.IGNORECASE)
@@ -24,50 +28,50 @@ def _extract_languages_from_filename(filename: str) -> Tuple[str, str]:
     if match:
         src = match.group(1)
         tgt = match.group(2)
-        print(f"  Found language pattern: {src} -> {tgt}")
+        logger.debug("  Found language pattern: %s -> %s", src, tgt)
 
         src_expanded = expand_language_code(src)
         tgt_expanded = expand_language_code(tgt)
 
-        print(f"  Expanded: {src_expanded} -> {tgt_expanded}")
+        logger.debug("  Expanded: %s -> %s", src_expanded, tgt_expanded)
         return src_expanded, tgt_expanded
 
-    print("  No language pattern found in filename")
+    logger.debug("  No language pattern found in filename")
     return "", ""
 
 
 def _extract_language_from_taskinfo(taskinfo: ET.Element) -> str:
     """Извлекает целевой язык из элемента taskInfo."""
-    print("Extracting language from taskInfo...")
+    logger.debug("Extracting language from taskInfo...")
 
     lang_element = taskinfo.find("language")
     if lang_element is not None:
         lang_name = lang_element.get("name", "").strip()
         lcid = lang_element.get("lcid", "").strip()
 
-        print(f"  Language element found: name='{lang_name}', lcid='{lcid}'")
+        logger.debug("  Language element found: name='%s', lcid='%s'", lang_name, lcid)
 
         normalized = normalize_language_name(lang_name)
         if normalized:
-            print(f"  -> Normalized language: '{normalized}'")
+            logger.debug("  -> Normalized language: '%s'", normalized)
             return normalized
 
         normalized = normalize_language_name(lcid)
         if normalized:
-            print(f"  -> Normalized language from LCID: '{normalized}'")
+            logger.debug("  -> Normalized language from LCID: '%s'", normalized)
             return normalized
 
         if lang_name:
-            print(f"  -> Returning raw language name: '{lang_name}'")
+            logger.debug("  -> Returning raw language name: '%s'", lang_name)
             return lang_name
 
-    print("  No language found in taskInfo")
+    logger.debug("  No language found in taskInfo")
     return ""
 
 
 def _parse_analyse_element(analyse: ET.Element, unit: str = "words") -> Dict[str, float]:
     """Парсит элемент <analyse> и возвращает объемы по категориям."""
-    print("  Parsing analyse element...")
+    logger.debug("  Parsing analyse element...")
 
     values = {name: 0.0 for name in ROW_NAMES}
     unit_attr = unit.lower()
@@ -76,7 +80,7 @@ def _parse_analyse_element(analyse: ET.Element, unit: str = "words") -> Dict[str
     if new_elem is not None:
         new_words = float(new_elem.get(unit_attr, 0))
         values[ROW_NAMES[0]] += new_words
-        print(f"    New words: {new_words}")
+        logger.debug("    New words: %s", new_words)
 
     fuzzy_elements = analyse.findall("fuzzy")
     for fuzzy in fuzzy_elements:
@@ -84,7 +88,7 @@ def _parse_analyse_element(analyse: ET.Element, unit: str = "words") -> Dict[str
         max_val = int(fuzzy.get("max", 100))
         words = float(fuzzy.get(unit_attr, 0))
 
-        print(f"    Fuzzy {min_val}-{max_val}%: {words} words")
+        logger.debug("    Fuzzy %s-%s%%: %s words", min_val, max_val, words)
 
         if words > 0:
             if max_val <= 74:
@@ -98,40 +102,40 @@ def _parse_analyse_element(analyse: ET.Element, unit: str = "words") -> Dict[str
     if exact_elem is not None:
         exact_words = float(exact_elem.get(unit_attr, 0))
         values[ROW_NAMES[3]] += exact_words
-        print(f"    Exact matches: {exact_words}")
+        logger.debug("    Exact matches: %s", exact_words)
 
     repeated_elem = analyse.find("repeated")
     if repeated_elem is not None:
         repeated_words = float(repeated_elem.get(unit_attr, 0))
         values[ROW_NAMES[3]] += repeated_words
-        print(f"    Repeated: {repeated_words}")
+        logger.debug("    Repeated: %s", repeated_words)
 
     cross_repeated_elem = analyse.find("crossFileRepeated")
     if cross_repeated_elem is not None:
         cross_words = float(cross_repeated_elem.get(unit_attr, 0))
         values[ROW_NAMES[3]] += cross_words
-        print(f"    Cross-file repeated: {cross_words}")
+        logger.debug("    Cross-file repeated: %s", cross_words)
 
     in_context_elem = analyse.find("inContextExact")
     if in_context_elem is not None:
         in_context_words = float(in_context_elem.get(unit_attr, 0))
         values[ROW_NAMES[3]] += in_context_words
-        print(f"    In-context exact: {in_context_words}")
+        logger.debug("    In-context exact: %s", in_context_words)
 
     perfect_elem = analyse.find("perfect")
     if perfect_elem is not None:
         perfect_words = float(perfect_elem.get(unit_attr, 0))
         values[ROW_NAMES[3]] += perfect_words
-        print(f"    Perfect matches: {perfect_words}")
+        logger.debug("    Perfect matches: %s", perfect_words)
 
     locked_elem = analyse.find("locked")
     if locked_elem is not None:
         locked_words = float(locked_elem.get(unit_attr, 0))
         values[ROW_NAMES[3]] += locked_words
-        print(f"    Locked: {locked_words}")
+        logger.debug("    Locked: %s", locked_words)
 
     total_words = sum(values.values())
-    print(f"    Total words processed: {total_words}")
+    logger.debug("    Total words processed: %s", total_words)
 
     return values
 
@@ -167,7 +171,7 @@ def _parse_trados_report(
     path: str, unit: str
 ) -> Tuple[Dict[str, Dict[str, float]], List[str], bool, str]:
     filename = Path(path).name
-    print(f"Processing Trados report: {path}")
+    logger.info("Processing Trados report: %s", path)
 
     results: Dict[str, Dict[str, float]] = {}
     warnings: List[str] = []
@@ -178,20 +182,20 @@ def _parse_trados_report(
         tree = ET.parse(path)
         root = tree.getroot()
 
-        print(f"Root element: {root.tag}")
-        print(f"Root attributes: {root.attrib}")
+        logger.debug("Root element: %s", root.tag)
+        logger.debug("Root attributes: %s", root.attrib)
 
         if root.tag != "task":
-            print(f"WARNING: Expected 'task' root element, got '{root.tag}'")
+            logger.warning("Expected 'task' root element, got '%s'", root.tag)
 
         taskinfo = root.find("taskInfo")
         if taskinfo is None:
             warning_msg = f"{filename}: No taskInfo element found"
-            print(f"ERROR: {warning_msg}")
+            logger.error(warning_msg)
             warnings.append(warning_msg)
             return results, warnings, processed, placeholder
 
-        print(f"TaskInfo found: {taskinfo.attrib}")
+        logger.debug("TaskInfo found: %s", taskinfo.attrib)
 
         filename_only = Path(path).name
         src_lang, tgt_lang = _extract_languages_from_filename(filename_only)
@@ -204,7 +208,7 @@ def _parse_trados_report(
         if src_lang and tgt_lang:
             determined_source_lang = src_lang
             determined_target_lang = tgt_lang
-            print(f"Language pair from filename: {src_lang} → {tgt_lang}")
+            logger.info("Language pair from filename: %s → %s", src_lang, tgt_lang)
             if (
                 taskinfo_lang
                 and len(tgt_lang) <= 3
@@ -216,30 +220,32 @@ def _parse_trados_report(
             determined_source_lang = "EN"
             determined_target_lang = taskinfo_lang
             pair_key = f"EN → {taskinfo_lang}"
-            print(f"Language pair from taskInfo: {pair_key}")
+            logger.info("Language pair from taskInfo: %s", pair_key)
 
         if not pair_key:
             warning_msg = (
                 f"{filename}: Could not determine language pair (src='{src_lang}', tgt='{tgt_lang}', taskinfo='{taskinfo_lang}')."
                 " Please assign the correct language pair manually."
             )
-            print(f"ERROR: {warning_msg}")
+            logger.error(warning_msg)
             warnings.append(warning_msg)
             return results, warnings, processed, placeholder
 
         placeholder = determined_target_lang or pair_key
 
-        print(
-            f"Final determined pair: '{determined_source_lang}' → '{determined_target_lang}'"
+        logger.info(
+            "Final determined pair: '%s' → '%s'",
+            determined_source_lang,
+            determined_target_lang,
         )
-        print(f"Pair key: '{pair_key}'")
+        logger.debug("Pair key: '%s'", pair_key)
 
         file_elements = root.findall("file")
-        print(f"Found {len(file_elements)} file elements")
+        logger.info("Found %s file elements", len(file_elements))
 
         if not file_elements:
             warning_msg = f"{filename}: No file elements found"
-            print(f"ERROR: {warning_msg}")
+            logger.error(warning_msg)
             warnings.append(warning_msg)
             return results, warnings, processed, placeholder
 
@@ -249,11 +255,13 @@ def _parse_trados_report(
 
         for j, file_elem in enumerate(file_elements):
             file_name = file_elem.get("name", f"file_{j}")
-            print(f"\n  Processing file {j + 1}/{len(file_elements)}: {file_name}")
+            logger.info(
+                "Processing file %s/%s: %s", j + 1, len(file_elements), file_name
+            )
 
             analyse_elem = file_elem.find("analyse")
             if analyse_elem is None:
-                print(f"    No analyse element in file {file_name}")
+                logger.warning("No analyse element in file %s", file_name)
                 continue
 
             file_values = _parse_analyse_element(analyse_elem, unit)
@@ -262,34 +270,39 @@ def _parse_trados_report(
                 add_val = file_values[name]
                 pair_values[name] += add_val
                 if add_val > 0:
-                    print(f"    {name}: +{add_val} (now {pair_values[name]})")
+                    logger.debug(
+                        "    %s: +%s (now %s)", name, add_val, pair_values[name]
+                    )
 
             file_total = sum(file_values.values())
             pair_total_words += file_total
-            print(f"    File total: {file_total} words")
+            logger.debug("    File total: %s words", file_total)
             files_processed_in_pair += 1
 
         results[pair_key] = pair_values
 
-        print(
-            f"\nPair {pair_key} total: {pair_total_words} words from {files_processed_in_pair} files"
+        logger.info(
+            "Pair %s total: %s words from %s files",
+            pair_key,
+            pair_total_words,
+            files_processed_in_pair,
         )
 
         if pair_total_words > 0:
             processed = True
-            print(f"✓ Successfully processed report: {pair_key}")
+            logger.info("Successfully processed report: %s", pair_key)
         else:
             warning_msg = f"{filename}: No words found in any file"
-            print(f"WARNING: {warning_msg}")
+            logger.warning(warning_msg)
             warnings.append(warning_msg)
 
     except ET.ParseError as exc:
         error_msg = f"{filename}: XML Parse Error - {exc}"
-        print(f"ERROR: {error_msg}")
+        logger.error(error_msg)
         warnings.append(error_msg)
     except Exception as exc:
         error_msg = f"{filename}: Unexpected error - {exc}"
-        print(f"ERROR: {error_msg}")
+        logger.exception(error_msg)
         warnings.append(error_msg)
 
     return results, warnings, processed, placeholder
@@ -299,8 +312,8 @@ def parse_reports(
     paths: List[str], unit: str = "Words"
 ) -> Tuple[Dict[str, Dict[str, float]], List[str], Dict[str, List[str]]]:
     """Парсит Trados и Smartcat XML отчёты и возвращает агрегированные объёмы."""
-    print(f"Starting to parse {len(paths)} XML reports...")
-    print(f"Unit: {unit}")
+    logger.info("Starting to parse %s XML reports...", len(paths))
+    logger.info("Unit: %s", unit)
 
     results: Dict[str, Dict[str, float]] = {}
     warnings: List[str] = []
@@ -309,7 +322,9 @@ def parse_reports(
     successfully_processed = 0
 
     for i, path in enumerate(paths):
-        print(f"\n--- Processing file {i + 1}/{len(paths)}: {path} ---")
+        logger.info(
+            "Processing file %s/%s: %s", i + 1, len(paths), path
+        )
         filename = Path(path).name
 
         if is_smartcat_report(path):
@@ -326,45 +341,47 @@ def parse_reports(
         if file_results:
             for pair_key in file_results:
                 if pair_key not in results:
-                    print(f"✓ Created new entry for pair: {pair_key}")
+                    logger.info("Created new entry for pair: %s", pair_key)
                 else:
-                    print(f"→ Adding to existing pair: {pair_key}")
+                    logger.debug("Adding to existing pair: %s", pair_key)
                 sources_map[pair_key].add(filename)
             _merge_pair_results(results, file_results)
         else:
             if not file_warnings:
                 msg = f"{filename}: Отчёт не удалось обработать"
-                print(f"ERROR: {msg}")
+                logger.error(msg)
                 warnings.append(msg)
             placeholder_name = placeholder or filename
             created_key = _ensure_placeholder_entry(results, placeholder_name, filename)
-            print(f"  Added placeholder entry for '{created_key}'")
+            logger.info("Added placeholder entry for '%s'", created_key)
             sources_map[created_key].add(filename)
 
         if processed:
             successfully_processed += 1
 
-    print("\n=== FINAL RESULTS ===")
-    print(f"Successfully processed: {successfully_processed}/{len(paths)} reports")
-    print(f"Found {len(results)} unique language pairs:")
+    logger.info("=== FINAL RESULTS ===")
+    logger.info(
+        "Successfully processed: %s/%s reports", successfully_processed, len(paths)
+    )
+    logger.info("Found %s unique language pairs:", len(results))
 
     sorted_pairs = sorted(results.items(), key=lambda x: x[0])
 
     for i, (pair_key, values) in enumerate(sorted_pairs, 1):
         total = sum(values.values())
-        print(f"  {i}. {pair_key}: {total:,.0f} total words")
+        logger.info("  %s. %s: %s total words", i, pair_key, f"{total:,.0f}")
         for name, value in values.items():
             if value > 0:
-                print(f"     • {name}: {value:,.0f}")
+                logger.info("     • %s: %s", name, f"{value:,.0f}")
 
-    print("\nUnique language pairs detected:")
+    logger.info("Unique language pairs detected:")
     for pair_key in sorted(results.keys()):
-        print(f"  • {pair_key}")
+        logger.info("  • %s", pair_key)
 
     if warnings:
-        print(f"\nWarnings/Errors ({len(warnings)}):")
+        logger.warning("Warnings/Errors (%s):", len(warnings))
         for warning in warnings:
-            print(f"  ❌ {warning}")
+            logger.warning("  ❌ %s", warning)
 
     sources = {pair: sorted(names) for pair, names in sources_map.items()}
 


### PR DESCRIPTION
## Summary
- add a centralized logging module with rotating file output under the application data directory
- replace scattered print statements with structured logger calls across the XML parsers and exporters
- update exporter logging to rely on the shared logger configuration instead of ad-hoc handlers

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'babel')*


------
https://chatgpt.com/codex/tasks/task_e_68e43e1ad504832cbb25de8f0b1710c3