### PR TITLE
Refactor rate handling into shared services

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -39,7 +39,8 @@ from gui.additional_services import AdditionalServicesWidget
 from gui.project_manager_dialog import ProjectManagerDialog
 from gui.project_setup_widget import ProjectSetupWidget
 from gui.styles import APP_STYLE
-from gui.utils import shorten_locale, format_amount
+from gui.utils import shorten_locale
+from logic.number_format import format_amount
 from gui.rates_import_dialog import ExcelRatesDialog
 from gui.background_workers import (
     ExcelExportWorker,

--- a/gui/rate_currency_mixin.py
+++ b/gui/rate_currency_mixin.py
@@ -1,0 +1,41 @@
+"""Shared behaviour for widgets that manage rate and currency data."""
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+
+from PySide6.QtWidgets import QTableWidgetItem
+
+from logic.number_format import (
+    convert_rate_value,
+    decimal_separator_for_lang,
+)
+
+
+class RateCurrencyMixin:
+    """Provide helpers for converting rate values inside widgets."""
+
+    def iter_rate_items(self) -> Iterable[QTableWidgetItem | None]:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    def _rate_decimal_separator(self) -> str:
+        lang = getattr(self, "lang", "ru")
+        return decimal_separator_for_lang(lang)
+
+    def convert_rates(self, multiplier: float) -> None:
+        separator = self._rate_decimal_separator()
+        for item in self._iter_existing_items():
+            value = item.text() if item is not None else "0"
+            updated = convert_rate_value(value, multiplier, separator)
+            if item is None:
+                continue
+            item.setText(updated)
+        self._after_rates_converted()
+
+    def _iter_existing_items(self) -> Iterator[QTableWidgetItem | None]:
+        for item in self.iter_rate_items():
+            yield item
+
+    def _after_rates_converted(self) -> None:
+        update = getattr(self, "update_sums", None)
+        if callable(update):
+            update()

--- a/gui/utils.py
+++ b/gui/utils.py
@@ -1,57 +1,10 @@
-from typing import Union
 import re
-
 from babel import Locale
 
 from logic.language_codes import RU_TERRITORY_ABBREVIATIONS
 
 
 RU_SHORT_TERRITORIES = RU_TERRITORY_ABBREVIATIONS
-
-
-def format_rate(value: Union[int, float, str], sep: str | None = None) -> str:
-    """Format rate according to GUI rules.
-
-    Accepts numbers or strings using either ``","`` or ``"."`` as decimal
-    separators and preserves the separator in the output.
-
-    Numbers are formatted with up to three decimals. If the formatted
-    string ends with two or three zeros after the decimal separator,
-    trim one trailing zero so that ``3.300`` becomes ``3.30`` and
-    ``3.000`` becomes ``3.00``.
-    """
-    if isinstance(value, str):
-        raw = value.strip()
-        if sep is None:
-            sep = "," if "," in raw and "." not in raw else "."
-        num = float(raw.replace(",", "."))
-    else:
-        num = float(value)
-        sep = sep or "."
-    text = f"{num:.3f}"
-    if text.endswith("000"):
-        text = text[:-1]
-    elif text.endswith("00"):
-        text = text[:-1]
-    if sep == ",":
-        text = text.replace(".", ",")
-    return text
-
-
-def format_amount(value: float, lang: str) -> str:
-    """Format monetary values with locale-aware separators."""
-    if lang == "en":
-        return f"{value:,.2f}"
-    # Russian: space for thousands and comma for decimals
-    return f"{value:,.2f}".replace(",", " ").replace(".", ",")
-
-
-def _to_float(value: str) -> float:
-    """Safely convert string to float."""
-    try:
-        return float((value or "0").replace(",", "."))
-    except ValueError:
-        return 0.0
 
 
 def shorten_locale(text: str, lang: str) -> str:

--- a/logic/number_format.py
+++ b/logic/number_format.py
@@ -1,0 +1,92 @@
+"""Utilities for converting and formatting numeric values consistently.
+
+This module centralises all operations for parsing and formatting numeric
+values that are shared between the GUI layer and service layer.  The goal is
+for widgets, exporters and other services to rely on the same canonical
+implementation instead of keeping local copies of helpers.
+"""
+from __future__ import annotations
+
+from typing import Union
+
+NumberLike = Union[int, float, str]
+
+_DEFAULT_RATE_DECIMALS = 3
+_DEFAULT_AMOUNT_DECIMALS = 2
+
+
+def rate_decimal_places() -> int:
+    """Return the standard amount of decimal places for rate values."""
+    return _DEFAULT_RATE_DECIMALS
+
+
+def amount_decimal_places() -> int:
+    """Return the standard amount of decimal places for monetary amounts."""
+    return _DEFAULT_AMOUNT_DECIMALS
+
+
+def decimal_separator_for_lang(lang: str) -> str:
+    """Return the decimal separator preferred for *lang*.
+
+    English interfaces default to a dot while all other languages use comma.
+    """
+    return "." if (lang or "").lower().startswith("en") else ","
+
+
+def parse_number(value: NumberLike) -> float:
+    """Convert *value* to ``float`` in a tolerant manner."""
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = (value or "0").strip()
+    # allow grouping spaces before converting
+    text = text.replace(" ", "")
+    try:
+        return float(text.replace(",", "."))
+    except ValueError:
+        return 0.0
+
+
+def _resolve_separator(value: NumberLike, preferred: str | None) -> str:
+    if preferred:
+        return preferred
+    if isinstance(value, str) and "," in value and "." not in value:
+        return ","
+    return "."
+
+
+def format_rate(value: NumberLike, separator: str | None = None) -> str:
+    """Format *value* as a rate string with canonical precision."""
+    sep = _resolve_separator(value, separator)
+    number = parse_number(value)
+    text = f"{number:.{rate_decimal_places()}f}"
+    if text.endswith("000"):
+        text = text[:-1]
+    elif text.endswith("00"):
+        text = text[:-1]
+    if sep == ",":
+        text = text.replace(".", ",")
+    return text
+
+
+def format_amount(value: NumberLike, lang: str) -> str:
+    """Format a monetary amount using locale specific separators."""
+    number = parse_number(value)
+    formatted = f"{number:,.{amount_decimal_places()}f}"
+    if (lang or "").lower().startswith("en"):
+        return formatted
+    return formatted.replace(",", " ").replace(".", ",")
+
+
+def convert_rate_value(value: NumberLike, multiplier: float, separator: str | None = None) -> str:
+    """Multiply *value* by *multiplier* and return formatted rate text."""
+    return format_rate(parse_number(value) * multiplier, separator)
+
+
+def currency_suffix(symbol: str | None) -> str:
+    return f" ({symbol})" if symbol else ""
+
+
+def with_currency_suffix(text: str, symbol: str | None) -> str:
+    return f"{text}{currency_suffix(symbol)}"
+
+


### PR DESCRIPTION
## Summary
- centralize numeric parsing and formatting in `logic/number_format.py` and reuse it across the GUI and exporter
- add a reusable `RateCurrencyMixin` to remove duplicated rate conversion logic in GUI widgets
- update the Excel exporter to rely on the shared number formatting rules for consistent rate/amount formats

## Testing
- pytest *(fails: missing babel dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e44401e5c4832c9de37663c0c269b2